### PR TITLE
More flexible input/output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Add methods for using various types of input.
+- Add methods for more flexible input and output.
 
 ## 0.5.2 - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Add methods for using various types of input.
+
+## 0.5.2 - 2022-02-14
+
 - Move all unit tests into `tests.rs` files to not reduce the code coverage involuntarily.
 - Upgrade the version of the dependency `nom` to *7.1.0*.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netcdf3"
-version = "0.5.2"
-authors = ["Julien Bt"]
+version = "0.5.3"
+authors = ["Julien Bt", "Robert Schiwon"]
 edition = "2018"
 description = "A pure Rust library for reading and writing NetCDF-3 files"
 documentation = "https://docs.rs/netcdf3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netcdf3"
 version = "0.5.3"
-authors = ["Julien Bt", "Robert Schiwon"]
+authors = ["Julien Bt"]
 edition = "2018"
 description = "A pure Rust library for reading and writing NetCDF-3 files"
 documentation = "https://docs.rs/netcdf3"

--- a/src/io/file_reader.rs
+++ b/src/io/file_reader.rs
@@ -1,5 +1,3 @@
-mod tests_file_reader;
-
 use std::fmt::Debug;
 use std::convert::TryFrom;
 use std::rc::Rc;
@@ -48,6 +46,14 @@ use crate::{
 
 pub trait SeekRead: Seek + Read {}
 impl<T: Seek + Read> SeekRead for T {}
+
+impl Debug for dyn SeekRead
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error>
+    {
+        write!(f, "{:p}", self)
+    }
+}
 
 /// Allows to read NetCDF-3 files (the *classic* and the *64-bit offset* versions).
 ///
@@ -215,14 +221,6 @@ pub struct FileReader {
     input_file_path: PathBuf,
     input_file: Box<dyn SeekRead>,
     vars_info: Vec<VariableParsedMetadata>
-}
-
-impl Debug for dyn SeekRead
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error>
-    {
-        write!(f, "{:p}", self)
-    }
 }
 
 macro_rules! impl_read_typed_var {

--- a/src/io/file_writer.rs
+++ b/src/io/file_writer.rs
@@ -161,6 +161,17 @@ macro_rules! impl_write_typed_chunk_nc_fill {
     };
 }
 
+pub trait SeekWrite: Seek + Write {}
+impl<T: Seek + Write> SeekWrite for T {}
+
+impl core::fmt::Debug for dyn SeekWrite
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error>
+    {
+        write!(f, "{:p}", self)
+    }
+}
+
 /// Allows to write NetCDF-3 files (the *classic* and the *64-bit offset* versions).
 ///
 /// # Example
@@ -240,8 +251,8 @@ pub struct FileWriter<'a>
 {
     /// Path of the output file
     output_file_path: PathBuf,
-    /// Opened file on the file system
-    output_file: std::fs::File,
+    /// Opened file
+    output_file: Box<dyn SeekWrite>,
     /// Defintion of the data set.
     header_def: Option<HeaderDefinition<'a>>,
     /// List of already written records of each variable
@@ -249,6 +260,18 @@ pub struct FileWriter<'a>
 }
 
 impl<'a> FileWriter<'a> {
+    /// Opens output for writing.
+    pub fn open_seek_write(file_name: &str, output: Box<dyn SeekWrite>) -> Result<Self, WriteError>
+    {
+        let path: PathBuf = PathBuf::from(file_name);
+
+        Ok(FileWriter{
+            output_file: output,
+            output_file_path: path,
+            header_def: None,
+            written_records: vec![],
+        })
+    }
 
     /// Opens and overwrites an existing NetCDF-3 file or creates one.
      pub fn open<P: std::convert::AsRef<Path>>(output_file_path: P) -> Result<FileWriter<'a>, WriteError> {
@@ -266,7 +289,7 @@ impl<'a> FileWriter<'a> {
             .append(false)
             .open(output_file_path.clone())?;
         Ok(FileWriter{
-            output_file: output_file,
+            output_file: Box::new(output_file),
             output_file_path: output_file_path,
             header_def: None,
             written_records: vec![],
@@ -290,7 +313,7 @@ impl<'a> FileWriter<'a> {
             .create_new(true)
             .open(output_file_path.clone())?;
         Ok(FileWriter{
-            output_file: output_file,
+            output_file: Box::new(output_file),
             output_file_path: output_file_path,
             header_def: None,
             written_records: vec![],

--- a/src/io/file_writer.rs
+++ b/src/io/file_writer.rs
@@ -704,6 +704,7 @@ impl <'a> HeaderDefinition<'a> {
 #[derive(Debug)]
 struct  ComputedDataSetMetadata<'a> {
     /// The number of bytes required for the header (containing useful bytes)
+    #[allow(dead_code)]
     header_required_size: usize,
     /// The number of the bytes of the zero padding append to the header
     header_zero_padding_size: usize,

--- a/tests/tests_read_nc3_files.rs
+++ b/tests/tests_read_nc3_files.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+use std::io::Cursor;
 use std::rc::Rc;
 
 use copy_to_tmp_file::{
@@ -64,18 +65,7 @@ const TEMP_F64_VAR_DATA: [f64; 30] = [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10
 const TEMP_F64_VAR_LEN: usize = TEMP_F64_VAR_DATA.len();
 
 
-
-#[test]
-fn test_read_file_nc3_classic() {
-
-    // Copy bytes to a temporary file
-    // ------------------------------
-    let (tmp_dir, input_data_file_path) = copy_bytes_to_tmp_file(NC3_CLASSIC_FILE_BYTES, NC3_CLASSIC_FILE_NAME);
-
-    // Open the NetCDF-3 file
-    // ----------------------
-    let mut file_reader = FileReader::open(input_data_file_path).unwrap();
-
+fn check_nc3_classic_data(mut file_reader: &mut FileReader) {
     // Check the NetCDF-3 definition
     // -----------------------------
     assert_eq!(Version::Classic,                                                    file_reader.version());
@@ -89,8 +79,38 @@ fn test_read_file_nc3_classic() {
     // Check the NetCDF-3 data
     // -----------------------
     check_temperatures_data(&mut file_reader);
+}
+
+#[test]
+fn test_read_file_nc3_classic() {
+
+    // Copy bytes to a temporary file
+    // ------------------------------
+    let (tmp_dir, input_data_file_path) = copy_bytes_to_tmp_file(NC3_CLASSIC_FILE_BYTES, NC3_CLASSIC_FILE_NAME);
+
+    // Open the NetCDF-3 file
+    // ----------------------
+    let mut file_reader = FileReader::open(input_data_file_path).unwrap();
+
+    check_nc3_classic_data(&mut file_reader);
 
     tmp_dir.close().unwrap();
+}
+
+#[test]
+/// Test reading files through an input that implement Seek and Read traits.
+fn test_read_file_nc3_classic_with_seek_read() {
+
+    // Create a cursor (implements Seek and Read traits) for reading they NetCDF-3 bytes.
+    // ------------------------------
+    let cursor = Cursor::new(NC3_CLASSIC_FILE_BYTES);
+    let boxed_cursor = Box::new(cursor);
+
+    // Open the NetCDF-3 file
+    // ----------------------
+    let mut file_reader = FileReader::open_seek_read(NC3_CLASSIC_FILE_NAME, boxed_cursor).unwrap();
+
+    check_nc3_classic_data(&mut file_reader);
 }
 
 #[test]

--- a/tests/tests_read_nc3_files.rs
+++ b/tests/tests_read_nc3_files.rs
@@ -98,7 +98,7 @@ fn test_read_file_nc3_classic() {
 }
 
 #[test]
-/// Test reading files through an input that implement Seek and Read traits.
+/// Test reading a file through an input that implement Seek and Read traits.
 fn test_read_file_nc3_classic_with_seek_read() {
 
     // Create a cursor (implements Seek and Read traits) for reading they NetCDF-3 bytes.


### PR DESCRIPTION
As described in https://github.com/julienbt/netcdf3/issues/2 this PR adds methods that allow to:
- Read from any source that implements the Seek/Read traits
- Write to any destination that implements the Seek/Write traits

This allows the library to be used with buffering and for build targets that do not offer a filesystem.

The changes should not break code for any existing users.

Looking forward to your feedback!